### PR TITLE
feat: 지식알림 스케쥴링 API & 이메일 유틸(#10)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 test {

--- a/src/docs/asciidoc/api/knowledge-subscribe/update-subscribe-knowledge.adoc
+++ b/src/docs/asciidoc/api/knowledge-subscribe/update-subscribe-knowledge.adoc
@@ -1,0 +1,18 @@
+=== 지식 업데이트 API
+
+==== 1. Curl Request
+
+include::{snippets}/update-subscribe-knowledge/curl-request.adoc[]
+
+==== 2. HTTP Request
+
+include::{snippets}/update-subscribe-knowledge/http-request.adoc[]
+
+==== 3. HTTP Request Param
+
+include::{snippets}/update-subscribe-knowledge/request-body.adoc[]
+
+==== 4. HTTP Response Body
+
+include::{snippets}/update-subscribe-knowledge/response-body.adoc[]
+include::{snippets}/update-subscribe-knowledge/response-fields.adoc[]

--- a/src/main/java/com/douunderstandapi/DoUUnderstandApiApplication.java
+++ b/src/main/java/com/douunderstandapi/DoUUnderstandApiApplication.java
@@ -2,7 +2,9 @@ package com.douunderstandapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class DoUUnderstandApiApplication {
 

--- a/src/main/java/com/douunderstandapi/common/utils/mail/EmailUtils.java
+++ b/src/main/java/com/douunderstandapi/common/utils/mail/EmailUtils.java
@@ -1,0 +1,79 @@
+package com.douunderstandapi.common.utils.mail;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EmailUtils {
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    private static final String DOMAIN_NAME = "DO-U-UNDERSTAND";
+    private static final String MORNING = "Morning";
+    private static final String AFTERNOON = "Afternoon";
+    private static final String EVENING = "Evening";
+
+    private final JavaMailSender javaMailSender;
+
+    public String sendSimpleMessage(String targetEmail, String subject, String content, String link) {
+        try {
+            MimeMessage message = createMessage(targetEmail, subject, content, link);
+            javaMailSender.send(message);
+            return "success";
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    private MimeMessage createMessage(String targetEmail, String subject, String content, String link)
+            throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        // targetEmail 보내는 대상
+        message.addRecipients(MimeMessage.RecipientType.TO, targetEmail);
+        message.setSubject(DOMAIN_NAME + " " + subject); //메일 제목
+
+        // 메일 내용 만들기 html text
+        String msg = createMailMessage(subject, content, link);
+
+        // subtype: html
+        message.setText(msg, "utf-8", "html");
+        message.setFrom(new InternetAddress(username, DOMAIN_NAME)); //보내는 사람의 메일 주소, 보내는 사람 이름
+
+        return message;
+    }
+
+    private String createMailMessage(String subject, String content, String link) {
+        LocalTime now = LocalTime.now();
+        String timeTextNow = findTimeTextByLocalTimeNow(now);
+        String msg = "<html><body style=\"font-family: 'Arial', sans-serif;\">";
+        msg += "<div style=\"background-color: #F4F4F4; padding: 30px; border-radius: 10px;\">";
+        msg += "<h1 style=\"font-size: 24px; color: #333;\">" + "[" + timeTextNow + "]" + subject + "</h1>";
+        msg += "<p style=\"font-size: 16px; color: #666;\">" + content + "</p>";
+        msg += "<p style=\"font-size: 16px; color: #666;\">아래 관련 링크에서 컨텐츠를 확인해보세요.</p>";
+        msg += "<div style=\"margin-top: 20px;\"><a href=\"" + link
+                + "\" style=\"display: inline-block; padding: 12px 24px; background-color: #007BFF; color: #fff; text-decoration: none; border-radius: 5px;\">컨텐츠 확인하기</a></div>";
+        msg += "</div></body></html>";
+        return msg;
+    }
+
+    private static String findTimeTextByLocalTimeNow(LocalTime now) {
+        if (now.isBefore(LocalTime.of(12, 59))) {
+            return MORNING;
+        } else if (now.isBefore(LocalTime.of(19, 59))) {
+            return AFTERNOON;
+        } else {
+            return EVENING;
+        }
+    }
+}

--- a/src/main/java/com/douunderstandapi/config/EmailConfig.java
+++ b/src/main/java/com/douunderstandapi/config/EmailConfig.java
@@ -1,0 +1,49 @@
+package com.douunderstandapi.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+
+//        properties.setProperty("mail.transport.protocol", "smtp"); // 프로토콜 설정
+        properties.setProperty("mail.smtp.auth", "true"); // smtp 인증
+        properties.setProperty("mail.smtp.starttls.enable", "true"); // smtp starttls 사용
+        properties.setProperty("mail.debug", "true"); // 디버그 사용
+//        properties.setProperty("mail.smtp.ssl.trust", "smtp.naver.com"); // ssl 인증 서버 주소
+        properties.setProperty("mail.smtp.ssl.enable", "true"); // ssl 사용
+        return properties;
+    }
+}

--- a/src/main/java/com/douunderstandapi/knowledge/controller/KnowledgeController.java
+++ b/src/main/java/com/douunderstandapi/knowledge/controller/KnowledgeController.java
@@ -1,11 +1,11 @@
-package com.douunderstandapi.knowledge.presentation;
+package com.douunderstandapi.knowledge.controller;
 
-import com.douunderstandapi.knowledge.application.KnowledgeService;
 import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeAddRequest;
 import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeUpdateRequest;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeAddResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeGetResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeUpdateResponse;
+import com.douunderstandapi.knowledge.service.KnowledgeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/douunderstandapi/knowledge/controller/KnowledgeSubscribeController.java
+++ b/src/main/java/com/douunderstandapi/knowledge/controller/KnowledgeSubscribeController.java
@@ -1,0 +1,27 @@
+package com.douunderstandapi.knowledge.controller;
+
+import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeSubscribeUpdateResponse;
+import com.douunderstandapi.knowledge.service.KnowledgeSubscribeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/knowledge")
+public class KnowledgeSubscribeController {
+
+    private final KnowledgeSubscribeService knowledgeSubscribeService;
+
+    @PatchMapping("/{knowledgeId}")
+    public ResponseEntity<KnowledgeSubscribeUpdateResponse> updateKnowledgeSubscribe(@PathVariable Long knowledgeId,
+                                                                                     @RequestParam Boolean isSubscribe) {
+        KnowledgeSubscribeUpdateResponse response = knowledgeSubscribeService.updateKnowledgeSubscribe(
+                knowledgeId, isSubscribe);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/douunderstandapi/knowledge/domain/Knowledge.java
+++ b/src/main/java/com/douunderstandapi/knowledge/domain/Knowledge.java
@@ -38,6 +38,12 @@ public class Knowledge {
     @Column(name = "is_understand", nullable = false)
     private Boolean isUnderstand;
 
+    @Column(name = "is_subscribe", nullable = false)
+    private Boolean isSubscribe;
+
+    @Column(name = "notification_count", nullable = false)
+    private Integer notificationCount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -47,6 +53,8 @@ public class Knowledge {
         this.content = content;
         this.link = link;
         this.isUnderstand = false;
+        this.isSubscribe = false;
+        this.notificationCount = 0;
         this.user = user;
     }
 
@@ -55,8 +63,22 @@ public class Knowledge {
     }
 
     public void update(KnowledgeUpdateRequest request) {
+        if (request == null) {
+            return;
+        }
         this.title = request.title();
         this.content = request.content();
         this.link = request.link();
+    }
+
+    public void updateSubscribeStatus(Boolean isSubscribe) {
+        if (isSubscribe == null) {
+            return;
+        }
+        this.isSubscribe = isSubscribe;
+    }
+
+    public void increaseNotificationCount() {
+        this.notificationCount++;
     }
 }

--- a/src/main/java/com/douunderstandapi/knowledge/domain/dto/response/KnowledgeSubscribeUpdateResponse.java
+++ b/src/main/java/com/douunderstandapi/knowledge/domain/dto/response/KnowledgeSubscribeUpdateResponse.java
@@ -1,0 +1,29 @@
+package com.douunderstandapi.knowledge.domain.dto.response;
+
+import com.douunderstandapi.knowledge.domain.Knowledge;
+
+public record KnowledgeSubscribeUpdateResponse(
+        Long id,
+        String title,
+        String content,
+        String link,
+        Boolean isUnderstand,
+        Boolean isSubscribe
+) {
+    public static KnowledgeSubscribeUpdateResponse of(Long id, String title, String content, String link,
+                                                      Boolean isUnderstand,
+                                                      Boolean isSubscribe) {
+        return new KnowledgeSubscribeUpdateResponse(id, title, content, link, isUnderstand, isSubscribe);
+    }
+
+    public static KnowledgeSubscribeUpdateResponse from(Knowledge knowledge) {
+        return KnowledgeSubscribeUpdateResponse.of(
+                knowledge.getId(),
+                knowledge.getTitle(),
+                knowledge.getContent(),
+                knowledge.getLink(),
+                knowledge.getIsUnderstand(),
+                knowledge.getIsSubscribe()
+        );
+    }
+}

--- a/src/main/java/com/douunderstandapi/knowledge/repository/KnowledgeRepository.java
+++ b/src/main/java/com/douunderstandapi/knowledge/repository/KnowledgeRepository.java
@@ -1,9 +1,12 @@
-package com.douunderstandapi.knowledge.infrastructure.repository;
+package com.douunderstandapi.knowledge.repository;
 
 import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface KnowledgeRepository extends JpaRepository<Knowledge, Long> {
+    List<Knowledge> findAllByUserAndIsSubscribe(User user, Boolean isSubscribe);
 }

--- a/src/main/java/com/douunderstandapi/knowledge/service/KnowledgeService.java
+++ b/src/main/java/com/douunderstandapi/knowledge/service/KnowledgeService.java
@@ -1,4 +1,4 @@
-package com.douunderstandapi.knowledge.application;
+package com.douunderstandapi.knowledge.service;
 
 import com.douunderstandapi.common.enumtype.ErrorCode;
 import com.douunderstandapi.common.exception.CustomException;
@@ -8,9 +8,9 @@ import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeUpdateRequest;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeAddResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeGetResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeUpdateResponse;
-import com.douunderstandapi.knowledge.infrastructure.repository.KnowledgeRepository;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
 import com.douunderstandapi.user.domain.User;
-import com.douunderstandapi.user.infrastructure.repository.UserRepository;
+import com.douunderstandapi.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/douunderstandapi/knowledge/service/KnowledgeSubscribeService.java
+++ b/src/main/java/com/douunderstandapi/knowledge/service/KnowledgeSubscribeService.java
@@ -1,0 +1,28 @@
+package com.douunderstandapi.knowledge.service;
+
+import com.douunderstandapi.common.enumtype.ErrorCode;
+import com.douunderstandapi.common.exception.CustomException;
+import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeSubscribeUpdateResponse;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class KnowledgeSubscribeService {
+
+    private final KnowledgeRepository knowledgeRepository;
+
+    public KnowledgeSubscribeUpdateResponse updateKnowledgeSubscribe(Long knowledgeId, Boolean isSubscribe) {
+        Knowledge knowledge = knowledgeRepository
+                .findById(knowledgeId)
+                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.NOT_EXIST_KNOWLEDGE_ID));
+
+        knowledge.updateSubscribeStatus(isSubscribe);
+        return KnowledgeSubscribeUpdateResponse.from(knowledge);
+    }
+}

--- a/src/main/java/com/douunderstandapi/notification/service/NotificationService.java
+++ b/src/main/java/com/douunderstandapi/notification/service/NotificationService.java
@@ -1,0 +1,67 @@
+package com.douunderstandapi.notification.service;
+
+import com.douunderstandapi.common.utils.mail.EmailUtils;
+import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
+import com.douunderstandapi.user.domain.User;
+import com.douunderstandapi.user.repository.UserRepository;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class NotificationService {
+
+    private final KnowledgeRepository knowledgeRepository;
+    private final UserRepository userRepository;
+    private final EmailUtils emailUtils;
+
+    @Scheduled(cron = "0 0 8 * * *")
+    public void sendUnderstandNotificationInMorning() {
+        List<User> users = findUserByAllowedNotification();
+        sendPriorityKnowledgeByEmail(users);
+    }
+
+    @Scheduled(cron = "0 0 13 * * *")
+    public void sendUnderstandNotificationInAfternoon() {
+        List<User> users = findUserByAllowedNotification();
+        sendPriorityKnowledgeByEmail(users);
+    }
+
+    @Scheduled(cron = "0 0 20 * * *")
+    public void sendUnderstandNotificationInEvening() {
+        List<User> users = findUserByAllowedNotification();
+        sendPriorityKnowledgeByEmail(users);
+    }
+
+    private List<User> findUserByAllowedNotification() {
+        return userRepository.findAllByIsAllowedNotification(true);
+    }
+
+    private void sendPriorityKnowledgeByEmail(List<User> users) {
+        users.forEach(u -> {
+            List<Knowledge> knowledgesByUserSubscribe = knowledgeRepository.findAllByUserAndIsSubscribe(u,
+                    true);
+
+            // 알람 신청한 지식중 알람 카운터가 가장 적은것을 하나 전송한다(Round Robin)
+            knowledgesByUserSubscribe.stream()
+                    .min(Comparator.comparing(Knowledge::getNotificationCount))
+                    .ifPresent(k -> {
+                        k.increaseNotificationCount();
+                        sendEmail(u, k);
+                    });
+        });
+    }
+
+    private void sendEmail(User user, Knowledge knowledge) {
+        emailUtils.sendSimpleMessage(user.getEmail(), knowledge.getTitle(), knowledge.getContent(),
+                knowledge.getLink());
+    }
+}

--- a/src/main/java/com/douunderstandapi/user/controller/UserController.java
+++ b/src/main/java/com/douunderstandapi/user/controller/UserController.java
@@ -1,8 +1,8 @@
-package com.douunderstandapi.user.presentation;
+package com.douunderstandapi.user.controller;
 
-import com.douunderstandapi.user.application.UserService;
 import com.douunderstandapi.user.domain.dto.request.UserAddRequest;
 import com.douunderstandapi.user.domain.dto.response.UserAddResponse;
+import com.douunderstandapi.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/douunderstandapi/user/domain/User.java
+++ b/src/main/java/com/douunderstandapi/user/domain/User.java
@@ -30,16 +30,20 @@ public class User {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "is_authenticated", nullable = false)
+    @Column(name = "authenticated", nullable = false)
     private Boolean isAuthenticated;
 
-    private User(String email, String password) {
+    @Column(name = "allowed_notification", nullable = false)
+    private Boolean isAllowedNotification;
+
+    private User(String email, String password, Boolean isAllowedNotification) {
         this.email = email;
         this.password = password;
         this.isAuthenticated = false;
+        this.isAllowedNotification = isAllowedNotification;
     }
 
-    public static User of(String email, String password) {
-        return new User(email, password);
+    public static User of(String email, String password, Boolean isAllowedNotification) {
+        return new User(email, password, isAllowedNotification);
     }
 }

--- a/src/main/java/com/douunderstandapi/user/domain/dto/request/UserAddRequest.java
+++ b/src/main/java/com/douunderstandapi/user/domain/dto/request/UserAddRequest.java
@@ -4,10 +4,11 @@ import com.douunderstandapi.user.domain.User;
 
 public record UserAddRequest(
         String email,
-        String password
+        String password,
+        Boolean isAllowedNotification
 ) {
 
     public User toEntity() {
-        return User.of(email, password);
+        return User.of(email, password, isAllowedNotification);
     }
 }

--- a/src/main/java/com/douunderstandapi/user/domain/dto/response/UserAddResponse.java
+++ b/src/main/java/com/douunderstandapi/user/domain/dto/response/UserAddResponse.java
@@ -4,17 +4,20 @@ import com.douunderstandapi.user.domain.User;
 
 public record UserAddResponse(
         Long id,
-        String email
+        String email,
+        Boolean isAllowedNotification
 ) {
     public static UserAddResponse of(
             Long id,
-            String email) {
-        return new UserAddResponse(id, email);
+            String email,
+            Boolean isAllowedNotification) {
+        return new UserAddResponse(id, email, isAllowedNotification);
     }
 
     public static UserAddResponse from(User user) {
         return UserAddResponse.of(
                 user.getId(),
-                user.getEmail());
+                user.getEmail(),
+                user.getIsAllowedNotification());
     }
 }

--- a/src/main/java/com/douunderstandapi/user/repository/UserRepository.java
+++ b/src/main/java/com/douunderstandapi/user/repository/UserRepository.java
@@ -1,11 +1,15 @@
-package com.douunderstandapi.user.infrastructure.repository;
+package com.douunderstandapi.user.repository;
 
 import com.douunderstandapi.user.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByEmail(String email);
+
+    List<User> findAllByIsAllowedNotification(Boolean isAllowedNotification);
 }

--- a/src/main/java/com/douunderstandapi/user/service/UserService.java
+++ b/src/main/java/com/douunderstandapi/user/service/UserService.java
@@ -1,20 +1,20 @@
-package com.douunderstandapi.user.application;
+package com.douunderstandapi.user.service;
 
 import com.douunderstandapi.user.domain.User;
 import com.douunderstandapi.user.domain.dto.request.UserAddRequest;
 import com.douunderstandapi.user.domain.dto.response.UserAddResponse;
-import com.douunderstandapi.user.infrastructure.repository.UserRepository;
+import com.douunderstandapi.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public UserAddResponse addUser(UserAddRequest request) {
         User user = request.toEntity();
         userRepository.save(user);

--- a/src/test/java/com/douunderstandapi/common/utils/mail/EmailUtilsTest.java
+++ b/src/test/java/com/douunderstandapi/common/utils/mail/EmailUtilsTest.java
@@ -1,0 +1,28 @@
+package com.douunderstandapi.common.utils.mail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EmailUtilsTest {
+
+    @Autowired
+    private EmailUtils emailUtils;
+
+    @Test
+    @DisplayName("Email 전송 테스트")
+    void sendSimpleMessage() {
+        String email = "sooable@gmail.com";
+        String subject = "subject";
+        String content = "content";
+        String link = "link";
+
+        String res = emailUtils.sendSimpleMessage(email, subject, content, link);
+
+        assertThat(res).isEqualTo("success");
+    }
+}

--- a/src/test/java/com/douunderstandapi/knowledge/controller/KnowledgeControllerTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/controller/KnowledgeControllerTest.java
@@ -1,4 +1,4 @@
-package com.douunderstandapi.knowledge.presentation;
+package com.douunderstandapi.knowledge.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -15,12 +15,12 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.douunderstandapi.knowledge.application.KnowledgeService;
 import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeAddRequest;
 import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeUpdateRequest;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeAddResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeGetResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeUpdateResponse;
+import com.douunderstandapi.knowledge.service.KnowledgeService;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -135,6 +135,7 @@ class KnowledgeControllerTest {
         request.put("title", "RESTful API 이해하기");
         request.put("content", "Restful API란.....222");
         request.put("link", "https://abcdefssss/2in2/update");
+        request.put("email", "test@gmail.com");
 
         when(knowledgeService.update(any(Long.class), any(KnowledgeUpdateRequest.class)))
                 .thenReturn(createKnowledgeUpdateResponse());
@@ -152,7 +153,8 @@ class KnowledgeControllerTest {
                                 requestFields(
                                         fieldWithPath("title").type(STRING).description("제목"),
                                         fieldWithPath("content").type(STRING).description("컨텐츠"),
-                                        fieldWithPath("link").type(STRING).description("관련링크")
+                                        fieldWithPath("link").type(STRING).description("관련링크"),
+                                        fieldWithPath("email").type(STRING).description("유저 이메일")
                                 ),
                                 responseFields(
                                         fieldWithPath("id")

--- a/src/test/java/com/douunderstandapi/knowledge/controller/KnowledgeSubscribeControllerTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/controller/KnowledgeSubscribeControllerTest.java
@@ -1,0 +1,85 @@
+package com.douunderstandapi.knowledge.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeSubscribeUpdateResponse;
+import com.douunderstandapi.knowledge.service.KnowledgeSubscribeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] - 지식구독")
+@WebMvcTest(KnowledgeSubscribeController.class)
+@AutoConfigureRestDocs
+class KnowledgeSubscribeControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    private KnowledgeSubscribeService knowledgeSubscribeService;
+
+    @DisplayName("{PATCH} 지식구독 업데이트 - 정상호출")
+    @Test
+    void updateKnowledgeSubscribe() throws Exception {
+        when(knowledgeSubscribeService.updateKnowledgeSubscribe(any(Long.class), any(Boolean.class)))
+                .thenReturn(createKnowledgeSubscribeUpdateResponseResponse());
+
+        mvc.perform(
+                        RestDocumentationRequestBuilders.patch("/api/v1/knowledge/1")
+                                .param("isSubscribe", "true"))
+                .andDo(print())
+                .andDo(
+                        document(
+                                "update-subscribe-knowledge",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("id")
+                                                .type(NUMBER)
+                                                .description("지식 ID"),
+                                        fieldWithPath("title")
+                                                .type(STRING)
+                                                .description("제목"),
+                                        fieldWithPath("content")
+                                                .type(STRING)
+                                                .description("컨텐츠"),
+                                        fieldWithPath("link")
+                                                .type(STRING)
+                                                .description("관련링크"),
+                                        fieldWithPath("isUnderstand")
+                                                .type(BOOLEAN)
+                                                .description("이해여부"),
+                                        fieldWithPath("isSubscribe")
+                                                .type(BOOLEAN)
+                                                .description("구독여부")
+                                )
+
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    private KnowledgeSubscribeUpdateResponse createKnowledgeSubscribeUpdateResponseResponse() {
+        return KnowledgeSubscribeUpdateResponse.of(1L, "RESTful API 이해하기", "Restful API란.....",
+                "https://abcdefssss/2in2/update",
+                false, true);
+    }
+}

--- a/src/test/java/com/douunderstandapi/knowledge/domain/KnowledgeTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/domain/KnowledgeTest.java
@@ -37,9 +37,11 @@ class KnowledgeTest {
         assertThat(knowledge.getLink()).isEqualTo(link);
         assertThat(knowledge.getUser()).isSameAs(mockUser);
         assertThat(knowledge.getIsUnderstand()).isFalse();
+        assertThat(knowledge.getIsSubscribe()).isFalse();
+        assertThat(knowledge.getNotificationCount()).isEqualTo(0);
     }
 
     private User createUser() {
-        return User.of("test@gmail.com", "password1!");
+        return User.of("test@gmail.com", "password1!", true);
     }
 }

--- a/src/test/java/com/douunderstandapi/knowledge/repository/KnowledgeRepositoryTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/repository/KnowledgeRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.douunderstandapi.knowledge.repository;
+
+import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.user.domain.User;
+import com.douunderstandapi.user.repository.UserRepository;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+// @Convert의 Converter를 DataJpaTest 시 로드하지 않아 @SpringBootTest로 테스트 진행
+@SpringBootTest
+@Transactional
+@DisplayName("지식 레포지토리 테스트")
+class KnowledgeRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    KnowledgeRepository knowledgeRepository;
+
+    @Test
+    void findAllByUserAndIsSubscribe() {
+        String email = "test1@gmail.com";
+        String password = "password1!";
+        User user = createUser(email, password);
+
+        userRepository.save(user);
+
+        Knowledge knowledge1 = createKnowledge(user);
+        Knowledge knowledge2 = createKnowledge(user);
+
+        knowledge1.updateSubscribeStatus(true);
+        knowledge2.updateSubscribeStatus(true);
+
+        knowledgeRepository.save(knowledge1);
+        knowledgeRepository.save(knowledge2);
+
+        List<Knowledge> knowledgesBySubscribe = knowledgeRepository.findAllByUserAndIsSubscribe(user, true);
+
+        Assertions.assertThat(knowledgesBySubscribe.size()).isEqualTo(2);
+    }
+
+    private Knowledge createKnowledge(User user) {
+        return Knowledge.of("함수 네이밍 룰 컨벤션",
+                "GET 요청을 처리하는 메서드의 네이밍 규칭......",
+                "https://sdnksnd/sds123",
+                user);
+    }
+
+    private User createUser(String email, String password) {
+        return User.of(email, password, true);
+    }
+}

--- a/src/test/java/com/douunderstandapi/knowledge/service/KnowledgeServiceTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/service/KnowledgeServiceTest.java
@@ -1,4 +1,4 @@
-package com.douunderstandapi.knowledge.application;
+package com.douunderstandapi.knowledge.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,9 +12,9 @@ import com.douunderstandapi.knowledge.domain.dto.request.KnowledgeUpdateRequest;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeAddResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeGetResponse;
 import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeUpdateResponse;
-import com.douunderstandapi.knowledge.infrastructure.repository.KnowledgeRepository;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
 import com.douunderstandapi.user.domain.User;
-import com.douunderstandapi.user.infrastructure.repository.UserRepository;
+import com.douunderstandapi.user.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -107,6 +107,6 @@ class KnowledgeServiceTest {
     }
 
     private User createUser() {
-        return User.of("test@gmail.com", "password1!");
+        return User.of("test@gmail.com", "password1!", true);
     }
 }

--- a/src/test/java/com/douunderstandapi/knowledge/service/KnowledgeSubscribeServiceTest.java
+++ b/src/test/java/com/douunderstandapi/knowledge/service/KnowledgeSubscribeServiceTest.java
@@ -1,0 +1,48 @@
+package com.douunderstandapi.knowledge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.knowledge.domain.dto.response.KnowledgeSubscribeUpdateResponse;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
+import com.douunderstandapi.user.domain.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class KnowledgeSubscribeServiceTest {
+
+    @Mock
+    private KnowledgeRepository knowledgeRepository;
+
+    @InjectMocks
+    private KnowledgeSubscribeService knowledgeSubscribeService;
+
+    @Test
+    @DisplayName("지식 구독 업데이트 - 서비스 로직 테스트")
+    void updateKnowledgeSubscribe() {
+        when(knowledgeRepository.findById(any(Long.class))).thenReturn(Optional.of(createKnowledge()));
+
+        KnowledgeSubscribeUpdateResponse response = knowledgeSubscribeService.updateKnowledgeSubscribe(
+                1L, true);
+
+        assertThat(response.isSubscribe()).isTrue();
+    }
+
+    private Knowledge createKnowledge() {
+        return Knowledge.of("함수 네이밍 룰 컨벤션",
+                "GET 요청을 처리하는 메서드의 네이밍 규칭......",
+                "https://sdnksnd/sds123", createUser());
+    }
+
+    private User createUser() {
+        return User.of("test@gmail.com", "password1!", true);
+    }
+}

--- a/src/test/java/com/douunderstandapi/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/douunderstandapi/notification/service/NotificationServiceTest.java
@@ -1,0 +1,103 @@
+package com.douunderstandapi.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.douunderstandapi.common.utils.mail.EmailUtils;
+import com.douunderstandapi.knowledge.domain.Knowledge;
+import com.douunderstandapi.knowledge.repository.KnowledgeRepository;
+import com.douunderstandapi.user.domain.User;
+import com.douunderstandapi.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private KnowledgeRepository knowledgeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailUtils emailUtils;
+
+    @Spy
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("지식 알람 - 서비스 로직 테스트(아침)")
+    void sendUnderstandNotificationInMorning() {
+        List<User> users = List.of(createUser());
+        List<Knowledge> knowledges = List.of(createKnowledge());
+
+        when(userRepository.findAllByIsAllowedNotification(anyBoolean()))
+                .thenReturn(users);
+        when(knowledgeRepository.findAllByUserAndIsSubscribe(any(User.class), anyBoolean()))
+                .thenReturn(knowledges);
+        when(emailUtils.sendSimpleMessage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("success");
+
+        notificationService.sendUnderstandNotificationInMorning();
+
+        verify(notificationService, times(1)).sendUnderstandNotificationInMorning();
+    }
+
+    @Test
+    @DisplayName("지식 알람 - 서비스 로직 테스트(점심)")
+    void sendUnderstandNotificationInAfternoon() {
+        List<User> users = List.of(createUser());
+        List<Knowledge> knowledges = List.of(createKnowledge());
+
+        when(userRepository.findAllByIsAllowedNotification(anyBoolean()))
+                .thenReturn(users);
+        when(knowledgeRepository.findAllByUserAndIsSubscribe(any(User.class), anyBoolean()))
+                .thenReturn(knowledges);
+        when(emailUtils.sendSimpleMessage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("success");
+
+        notificationService.sendUnderstandNotificationInEvening();
+
+        verify(notificationService, times(1)).sendUnderstandNotificationInEvening();
+    }
+
+    @Test
+    @DisplayName("지식 알람 - 서비스 로직 테스트(저녁)")
+    void sendUnderstandNotificationInEvening() {
+        List<User> users = List.of(createUser());
+        List<Knowledge> knowledges = List.of(createKnowledge());
+
+        when(userRepository.findAllByIsAllowedNotification(anyBoolean()))
+                .thenReturn(users);
+        when(knowledgeRepository.findAllByUserAndIsSubscribe(any(User.class), anyBoolean()))
+                .thenReturn(knowledges);
+        when(emailUtils.sendSimpleMessage(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("success");
+
+        notificationService.sendUnderstandNotificationInAfternoon();
+
+        verify(notificationService, times(1)).sendUnderstandNotificationInAfternoon();
+    }
+
+    private Knowledge createKnowledge() {
+        return Knowledge.of("함수 네이밍 룰 컨벤션",
+                "GET 요청을 처리하는 메서드의 네이밍 규칭......",
+                "https://sdnksnd/sds123", createUser());
+    }
+
+    private User createUser() {
+        return User.of("test@gmail.com", "password1!", true);
+    }
+}

--- a/src/test/java/com/douunderstandapi/user/controller/UserControllerTest.java
+++ b/src/test/java/com/douunderstandapi/user/controller/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.douunderstandapi.user.presentation;
+package com.douunderstandapi.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -14,9 +15,9 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.douunderstandapi.user.application.UserService;
 import com.douunderstandapi.user.domain.dto.request.UserAddRequest;
 import com.douunderstandapi.user.domain.dto.response.UserAddResponse;
+import com.douunderstandapi.user.service.UserService;
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,7 @@ class UserControllerTest {
         JSONObject request = new JSONObject();
         request.put("email", "test@gmail.com");
         request.put("password", "1234");
+        request.put("isAllowedNotification", true);
 
         when(userService.addUser(any(UserAddRequest.class)))
                 .thenReturn(createUserAddResponse());
@@ -61,7 +63,8 @@ class UserControllerTest {
                                 preprocessResponse(prettyPrint()),
                                 requestFields(
                                         fieldWithPath("email").type(STRING).description("이메일"),
-                                        fieldWithPath("password").type(STRING).description("패스워드")
+                                        fieldWithPath("password").type(STRING).description("패스워드"),
+                                        fieldWithPath("isAllowedNotification").type(BOOLEAN).description("알람설정여부")
                                 ),
                                 responseFields(
                                         fieldWithPath("id")
@@ -69,7 +72,10 @@ class UserControllerTest {
                                                 .description("회원 ID"),
                                         fieldWithPath("email")
                                                 .type(STRING)
-                                                .description("이메일")
+                                                .description("이메일"),
+                                        fieldWithPath("isAllowedNotification")
+                                                .type(BOOLEAN)
+                                                .description("알람설정여부")
                                 )
                         )
                 )
@@ -77,6 +83,6 @@ class UserControllerTest {
     }
 
     private UserAddResponse createUserAddResponse() {
-        return UserAddResponse.of(1L, "tester@gmail.com");
+        return UserAddResponse.of(1L, "tester@gmail.com", true);
     }
 }

--- a/src/test/java/com/douunderstandapi/user/domain/UserTest.java
+++ b/src/test/java/com/douunderstandapi/user/domain/UserTest.java
@@ -13,7 +13,7 @@ class UserTest {
     void of() {
         String email = "test@gmail.com";
         String password = "password1!";
-        User user = User.of(email, password);
+        User user = User.of(email, password, true);
 
         assertThat(user.getEmail()).isEqualTo(email);
     }
@@ -23,11 +23,12 @@ class UserTest {
     void getter() {
         String email = "test@gmail.com";
         String password = "password1!";
-        User user = User.of(email, password);
+        User user = User.of(email, password, true);
 
         assertThat(user.getId()).isNull();
         assertThat(user.getPassword()).isEqualTo(password);
         assertThat(user.getEmail()).isEqualTo(email);
         assertThat(user.getIsAuthenticated()).isFalse();
+        assertThat(user.getIsAllowedNotification()).isTrue();
     }
 }

--- a/src/test/java/com/douunderstandapi/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/douunderstandapi/user/repository/UserRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.douunderstandapi.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.douunderstandapi.user.domain.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+// @Convert의 Converter를 DataJpaTest 시 로드하지 않아 @SpringBootTest로 테스트 진행
+@SpringBootTest
+@Transactional
+@DisplayName(value = "유저 레포지토리 테스트")
+class UserRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void findByEmail() {
+        String email = "test@gmail.com";
+        User user = createUser();
+        userRepository.save(user);
+
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        optionalUser.ifPresent(
+                u -> assertThat(u).isSameAs(user)
+        );
+    }
+
+    @Test
+    void findAllByIsAllowedNotification() {
+        User user1 = createUser();
+        User user2 = createUser();
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        List<User> usersByAllowedNotification = userRepository.findAllByIsAllowedNotification(true);
+
+        assertThat(usersByAllowedNotification.size()).isEqualTo(2);
+    }
+
+    private User createUser() {
+        return User.of("test@gmail.com", "password1!", true);
+    }
+}

--- a/src/test/java/com/douunderstandapi/user/service/UserServiceTest.java
+++ b/src/test/java/com/douunderstandapi/user/service/UserServiceTest.java
@@ -1,4 +1,4 @@
-package com.douunderstandapi.user.application;
+package com.douunderstandapi.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import com.douunderstandapi.user.domain.User;
 import com.douunderstandapi.user.domain.dto.request.UserAddRequest;
 import com.douunderstandapi.user.domain.dto.response.UserAddResponse;
-import com.douunderstandapi.user.infrastructure.repository.UserRepository;
+import com.douunderstandapi.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,13 +31,13 @@ class UserServiceTest {
         String email = "test@gmail.com";
         String password = "password1!";
 
-        UserAddRequest request = new UserAddRequest(email, password);
+        UserAddRequest request = new UserAddRequest(email, password, true);
         UserAddResponse response = userService.addUser(request);
 
         assertThat(response.email()).isEqualTo(email);
     }
 
     private User createUser() {
-        return User.of("test@gmail.com", "password1!");
+        return User.of("test@gmail.com", "password1!", true);
     }
 }


### PR DESCRIPTION
- [x] ✅ PR 제목의 형식을 잘 작성했나요? e.g. `feat: PR을 등록한다.`
- [x] ✅ 테스트는 잘 통과했나요?
- [x] ✅ 빌드는 성공했나요?
- [ ] ✅ 불필요한 코드는 제거했나요?
- [x] ✅ 이슈는 등록했나요?
- [x] ✅ 라벨은 등록했나요?
- [x] ✅ 코드 컨벤션은 지켰나요?
- [ ] ✅ pr 워크플로우를 돌려주세요.

## 작업 내용
1. 이메일 디펜던시 추가
- spring-boot-starter-mail
2. 이메일 유틸 컴포넌트(naver smtp)
- 이메일 전송, 이메일 텍스트 생성 책임
- EmailConfig 설정
3. notification 패키지 및 서비스
- @Scheduled 크론식을 활용해서 하루 3번 이메일 알람서비스
- 기본로직: 구독을 신청한 지식들중 카운트가 적은 지식 전송 이후 카운트 증가(RR)
4. 지식 구독 API(PATCH) 추가
5. 패키지 네이밍 및 구조 변경 리팩토링
6. 테스트 코드 작성
- 라인커버리지 95%

## 스크린샷

## 주의사항

Closes #10 